### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: "17"
+        java-version: "21"
         distribution: "temurin"
 
     - name: Setup Ghidra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *' # Monthly
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,33 +12,42 @@ permissions:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        ghidra:
+          - "latest"
+          - "11.1.2"
+          - "11.1.1"
+          - "11.1"
+          - "11.0.3"
+          - "11.0.2"
+          - "11.0.1"
+          - "11.0"
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Ghidra
-        run: |
-          cd /tmp
-          curl -s https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest \
-          | grep "browser_download_url.*zip" \
-          | cut -d : -f 2,3 \
-          | tr -d \" \
-          | wget -qi -
-          unzip ghidra*.zip -d /opt
-          rm ghidra*.zip
-          mv /opt/ghidra_* /opt/ghidra
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: "17"
-          distribution: "temurin"
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
-        env:
-          GHIDRA_INSTALL_DIR: /opt/ghidra
-        with:
-          arguments: buildExtension
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          path: dist/
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: "17"
+        distribution: "temurin"
+
+    - name: Setup Ghidra
+      uses: antoniovazquezblanco/setup-ghidra@v2.0.3
+      with:
+        version: ${{ matrix.ghidra }}
+
+    - name: Install Gradle
+      uses: gradle/actions/setup-gradle@v3
+
+    - name: Build
+      run: gradle buildExtension -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
+
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: Ghidracord_${{ matrix.ghidra }}
+        path: dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      ghidra_version:
+        description: 'Specify the Ghidra version(s) you want to build for (e.g. "latest", "11.0")'
+        required: true
+        default: '"latest"'
   schedule:
     - cron: '0 0 1 * *' # Monthly
 
@@ -15,15 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghidra:
-          - "latest"
-          - "11.1.2"
-          - "11.1.1"
-          - "11.1"
-          - "11.0.3"
-          - "11.0.2"
-          - "11.0.1"
-          - "11.0"
+        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.1.2","11.1.1","11.1","11.0.3","11.0.2","11.0.1","11.0"')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Ghidra
         run: |
           cd /tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: "17"
         distribution: "temurin"


### PR DESCRIPTION
- Triggering CI in all branches now
- Updated `setup-java` and `checkout` action to version 4
- Updated JDK to version 21
- Monthly build is added to verify the CI functionality and compatibility of the current code with the latest version of Ghidra
- Replaced manual download of Ghidra with a special action for this
- The following versions are now compiled by default: latest, versions from 11.1.2 to 11.0
- However, on the Actions page, you can manually run the build with the version(s) of Ghidra you need:

![ci](https://github.com/user-attachments/assets/d6c7583c-c746-43f2-9d5a-306537c09c3f)
